### PR TITLE
Improve controller spec

### DIFF
--- a/spec/support/controller_macros.rb
+++ b/spec/support/controller_macros.rb
@@ -1,17 +1,18 @@
 module ControllerMacros
+  def devise_login(key, user)
+    @request.env["devise.mapping"] = Devise.mappings[key]
+    sign_in(user)
+  end
+
+  def devise_user_login(user)
+    devise_login(:user, user)
+  end
+
   def login_admin
-    before(:each) do
-      @request.env["devise.mapping"] = Devise.mappings[:admin]
-      sign_in FactoryGirl.create(:admin) # Using factory girl as an example
-    end
+    before(:each){ devise_login(:admin, FactoryGirl.create(:admin)) }
   end
 
   def login_user
-    before(:each) do
-      @request.env["devise.mapping"] = Devise.mappings[:user]
-      @user = FactoryGirl.create(:user)
-      # user.confirm! # or set a confirmed_at inside the factory. Only necessary if you are using the "confirmable" module
-      sign_in @user
-    end
+    before(:each){ devise_login(:user, FactoryGirl.create(:user)) }
   end
 end

--- a/spec/support/devise.rb
+++ b/spec/support/devise.rb
@@ -1,7 +1,10 @@
 # https://github.com/plataformatec/devise/wiki/How-To:-Test-controllers-with-Rails-3-and-4-(and-RSpec)
 RSpec.configure do |config|
-  config.include Devise::TestHelpers, :type => :controller
-  config.extend ControllerMacros, :type => :controller
+  config.with_options(:type => :controller) do |c|
+    c.include Devise::Test::ControllerHelpers
+    c.include ControllerMacros
+    c.extend  ControllerMacros
+  end
 
   # For request spec
   # https://github.com/plataformatec/devise/wiki/How-To:-Test-with-Capybara


### PR DESCRIPTION
Enable to define user like this in controller spec:

```
  let(:user){ FactoryGirl.create(:user) }
  before{ devise_user_login(user) }
```

In order to avoid instantiate duplicated user.
